### PR TITLE
(fix)Change GitHub's Profile Color

### DIFF
--- a/Code.css
+++ b/Code.css
@@ -59,7 +59,7 @@
 }
 .connectedAccountContainer__5972d:hover:has([aria-label="GitHub"]) .connectedAccountNameText__7abc2,
 .connectedAccountContainer__5972d:hover:has([aria-label="GitHub"]) {
-  color: #8153c5 !important;
+  color: #fcfaff !important;
   }
 .profileColors_ac6ab4:where(.theme-dark) .connectedAccountContainer__5972d:hover:has([aria-label="X"]) {
   color: white !important;


### PR DESCRIPTION
For whatever reason the color was set to purple, which doesn't seem to make sense if we're going by the pattern of all the other connections. This just changes it to white (since the logo is mainly white)

Closed since it was fixed!